### PR TITLE
Fixed a typo in README.md, and it now uses _name to set the mappings name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ end
 
 In a SparkleFormation Template/Component/Dynamic:
 ```ruby
-registry!(:offical_amis, :name)
+registry!(:official_amis, :name)
 
 resources do
   ec2_instance do

--- a/lib/sparkleformation/registry/official_amis.rb
+++ b/lib/sparkleformation/registry/official_amis.rb
@@ -13,7 +13,7 @@ SfnRegistry.register(:official_amis) do |_name, _config = {}|
   ami_hash.each do |release, info|
     info[:amis].each do |region, ids|
       mappings do
-        official_amis do
+        set!(_name ? "#{_name}_official_amis" : "official_amis") do
           camel_keys_set!(:auto_disable)
           set!(region) do
             set!(info[:version], ids[virt][type])


### PR DESCRIPTION
This allows you to call :official_amis more than once so you can have multiple AMI mappings set-up.
